### PR TITLE
Do not activate child while parent isnt active

### DIFF
--- a/ios/RIBs/Classes/Router.swift
+++ b/ios/RIBs/Classes/Router.swift
@@ -137,7 +137,9 @@ open class Router<InteractorType>: Routing {
 
         // Activate child first before loading. Router usually attaches immutable children in didLoad.
         // We need to make sure the RIB is activated before letting it attach immutable children.
-        child.interactable.activate()
+        if interactable.isActive {
+            child.interactable.activate()
+        }
         child.load()
     }
 


### PR DESCRIPTION
This fix fixes cases when one riblet (parent) is created and it has some child riblets that are attached to parent router. In this case didBecomeActive methods are called for all child even if parent is not active right now. 
Activation of all child is made inside `bindSubtreeActiveState`
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
